### PR TITLE
BugFix

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -96,7 +96,7 @@ function App() {
       />
       <WeatherDisplay weatherData={weatherData} />
       {lat && lon && <WeatherMap latitude={lat} longitude={lon} />}
-      <h2>{weatherData.name} 5 day forecast</h2>
+      {weatherData && <h2>{weatherData.name} 5 day forecast</h2>}
       {forecastData && forecastData.length > 0 && (
         <WeatherForecast forecastData={forecastData} />
       )}


### PR DESCRIPTION
This modification ensures that the application doesn't try to access the name property of weatherData unless weatherData is defined, thus preventing the crash.